### PR TITLE
Add iTunes Library XML Parser

### DIFF
--- a/muslytics/ITunesXMLParser.py
+++ b/muslytics/ITunesXMLParser.py
@@ -89,7 +89,14 @@ def merge_duplicates(tracks):
             .format(removed=removed_count, remained=len(tracks)))
     return tracks
 
+
 def pickle_tracks(tracklist, filename=None):
+    """Pickle iTunes track list to file.
+
+    Args:
+        tracklist (list(ITunesTrack)): iTunes tracks to be pickled
+        filename (str): filename to pickle to, defaults to {current datetime}-tracklist.p
+    """
     if not filename:
         filename = '{date}-tracklist.p'.format(date=datetime.datetime.now()) 
 
@@ -99,7 +106,16 @@ def pickle_tracks(tracklist, filename=None):
     logger.info('Pickled {tracks} tracks to {filename}.'
                 .format(tracks=len(tracklist), filename=filename))
 
+
 def unpickle_tracks(filename):
+    """Unpickle an iTunes track list from file.
+
+    Args:
+        filename (str): name of the pickled file
+
+    Returns:
+        a list of ITunesTrack data
+    """
     with open(filename, 'rb') as file:
         tracklist = pickle.load(file)
 

--- a/muslytics/ITunesXMLParser.py
+++ b/muslytics/ITunesXMLParser.py
@@ -39,9 +39,6 @@ def merge_duplicates(tracks):
 
     Args:
         tracks (list(ITunesTrack)): tracks to be scanned for duplicates and merged where necessary
-
-    Returns:
-        a list of ITunesTracks with duplicates merged and extraneous tracks removed
     """
     identifier_to_index = {}
     duplicate_identifiers = set()
@@ -87,7 +84,6 @@ def merge_duplicates(tracks):
     
     logger.info('Removed {removed} duplicate tracks, {remained} tracks remain.'
             .format(removed=removed_count, remained=len(tracks)))
-    return tracks
 
 
 def pickle_tracks(tracklist, filename=None):
@@ -138,8 +134,7 @@ def extract_tracks(filepath):
         logger.error(err)
         raise Exception(err)
 
-    tracks = _get_tracks(_get_xml_tree(filepath))
-    return merge_duplicates(tracks)
+    return _get_tracks(_get_xml_tree(filepath))
 
 
 def _get_tracks(xml_tree):
@@ -226,6 +221,7 @@ if __name__ == '__main__':
 
     if args.xml:
         tracks = extract_tracks(args.xml)
+        merge_duplicates(tracks)
         pickle_tracks(tracks, args.pickle)
     else:
         tracks = unpickle_tracks(args.pickle)

--- a/muslytics/itunes_xml_parser.py
+++ b/muslytics/itunes_xml_parser.py
@@ -1,0 +1,274 @@
+#!/usr/bin/python
+'''parses itunes library xml'''
+from __future__ import absolute_import, print_function
+
+import argparse
+import logging
+import os
+
+from lxml import etree
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('iTunes XML Parser')
+
+TRACKS_XPATH = '/plist/dict/dict/dict'
+
+
+VIDEO_KEY = 'Has Video'
+ID_KEY = 'Track ID'
+NAME_KEY = 'Name'
+ARTIST_KEY = 'Artist'
+ALBUM_ARTIST_KEY = 'Album Artist'
+ALBUM_KEY = 'Album'
+YEAR_KEY = 'Year'
+GENRE_KEY = 'Genre'
+RATING_KEY = 'Rating'
+PLAY_COUNT_KEY = 'Play Count'
+
+REQUIRED_KEYS = [ID_KEY, NAME_KEY, ARTIST_KEY, ALBUM_KEY, YEAR_KEY, GENRE_KEY]
+
+
+class Track(object):
+    """Representation of an iTunes library music track."""
+
+    def __init__(self, id, name, artist, album, year, genre):
+        """Create a base music track.
+
+        Sets the id, name, artist, album, year, and genre as given.
+        Sets album_artist to artist, rating to None, and plays to 0.
+    
+        Args:
+            id (str): unique track id
+            name (str): track name
+            artist (str): track artist
+            album (str): track album
+            year (str): track year
+            genre (str): track genre
+
+        """
+        self.id = int(id)
+        self.name = name
+        self.artist = artist
+        self.album = album
+        self.year = int(year)
+        self.genre = genre
+
+        self.album_artist = artist
+        self.rating = None
+        self.plays = 0
+
+    def set_album_artist(self, album_artist):
+        """Set the track album artist if given a truthy value.
+
+        Args:
+            album_artist (str): track album artist
+        """
+        if album_artist:
+            self.album_artist = album_artist
+
+    def set_rating(self, rating=None):
+        """Set the track rating if given a truthy value.
+
+        Args:
+            rating (str): track rating, defaults to None
+        """
+        self.rating = int(rating) if rating is not None else None
+
+    def set_plays(self, plays=0):
+        """Set the track play count.
+
+        Args:
+            plays (str): track play count, defualts to 0
+        """
+        self.plays = int(plays)
+
+    def get_identifier(self):
+        """Retrieves a track identifier in the form of concatenated name, artist, year.
+
+        Intended to be used for identifying duplicate tracks.
+
+        Returns:
+            concatenated string of track name, artist, year
+        """
+        return '%s_%s_%s' % (self.name, self.artist, self.year)
+
+    def print_verbose(self):
+        """Creates a verbose string representation.
+        
+        Returns:
+            a verbose string representation of the track attributes
+        """
+        rstr = '%s:\t%d\n' % (ID_KEY, self.id)
+        rstr += '%s:\t\t%s\n' % (NAME_KEY, self.name)
+        rstr += '%s:\t\t%s\n' % (ARTIST_KEY, self.artist)
+        rstr += '%s:\t%s\n' % (ALBUM_ARTIST_KEY, self.album_artist)
+        rstr += '%s:\t\t%s\n' % (ALBUM_KEY, self.album)
+        rstr += '%s:\t\t%d\n' % (YEAR_KEY, self.year)
+        rstr += '%s:\t\t%s\n' % (GENRE_KEY, self.genre)
+        rstr += '%s:\t\t%s\n' % (RATING_KEY, self.rating)
+        rstr += '%s:\t%d\n' % (PLAY_COUNT_KEY, self.plays)
+
+        return rstr
+
+    def __repr__(self):
+        rstr = '(%d,%s,%s,%s,%s,%d,%s,%s,%d)' % \
+                (self.id, self.name, self.artist, self.album_artist, self.album,
+                        self.year, self.genre, self.rating, self.plays)
+        return rstr
+
+
+def merge_duplicates(tracks):
+    """Merge duplicate track rating and play count info.
+
+    Tracks are marked duplicates by equal get_identifier() results. The sum of the plays and
+    average of the ratings is used.
+
+    Args:
+        tracks (list(Track)): tracks to be scanned for duplicates and merged where necessary
+
+    Returns:
+        a list of Tracks with duplicates merged and extraneous tracks removed
+    """
+    identifier_to_index = {}
+    duplicate_identifiers = set()
+    removable = []
+    removed_count = 0
+
+    # here, track_ids are the string identifiers not the unique int ids
+    for i, track in enumerate(tracks):
+        track_id = track.get_identifier()
+        if track_id in identifier_to_index:
+            duplicate_identifiers.add(track_id)
+            identifier_to_index[track_id].append(i)
+            removable.append(i)
+        else:
+            identifier_to_index[track_id] = [i]
+
+    for duplicate_identifier in duplicate_identifiers:
+        logger.info('Identified duplicate track (%s).' % duplicate_identifier)
+        duplicate_indexes = identifier_to_index[duplicate_identifier]
+        duplicate_tracks = [tracks[i] for i in duplicate_indexes]
+        plays = 0
+        sum_rating = 0
+        dup_count = 0.
+        for track in duplicate_tracks:
+            plays += track.plays
+            if track.rating is not None:
+                sum_rating += track.rating
+                dup_count += 1
+
+        rating = sum_rating / dup_count if dup_count else None
+
+        # merge sum play counts and avg rating onto the first track and we'll
+        # remove the rest
+        merged_track = duplicate_tracks[0]
+        merged_track.set_plays(plays)
+        merged_track.set_rating(rating)
+
+    # remove the tracks whose info we merged
+    removable.reverse()
+    for i in removable:
+        del tracks[i]
+        removed_count += 1
+    
+    logger.info('Removed %d duplicate tracks, %d tracks remain.' % (removed_count, len(tracks)))
+    return tracks
+
+
+def extract_tracks(filepath):
+    """Extract music tracks from iTunes library XML.
+
+    Args:
+        filepath (str): iTunes library XML filepath
+
+    Returns:
+        a list of dict representing the tracks
+    """
+    if not os.path.isfile(filepath):
+        err = 'Invalid filepath %s' % (filepath)
+        logger.error(err)
+        raise Exception(err)
+
+    tracks = _get_tracks(_get_xml_tree(filepath))
+    return merge_duplicates(tracks)
+
+
+def _get_tracks(xml_tree):
+    """Extracts all music tracks containing the required info from the given XML tree.
+
+    Args:
+        xml_tree (lxml.etree): etree extracted from the iTunes library XML file
+
+    Returns:
+        a list of dict representing music tracks
+    """
+    tracks = []
+    added_count = 0
+    skipped_count = 0
+    # track_elems = [ Element ], representing individual track info
+    track_elems = xml_tree.xpath(TRACKS_XPATH)
+
+    for elem in track_elems:
+        # get the key and value names from the Elements
+        track_kv = [x.text for x in elem.getchildren()]
+        keys, values = track_kv[::2], track_kv[1::2]
+        # we don't care about music videos/tv shows/movies and this is one
+        if VIDEO_KEY in keys:
+            skipped_count += 1
+            continue
+
+        try:
+            track = _build_track(keys, values)
+            tracks.append(track)
+            added_count += 1
+        except Exception:
+            skipped_count += 1
+            continue
+ 
+    logger.info('Parsed %d tracks and skipped %d tracks.' % (added_count, skipped_count))
+
+    return tracks
+
+
+def _build_track(keys, values):
+    """Extract desired XML track data.
+
+    Extracts the id, name, artist, album artist, album, year, genre, rating, and play counts from
+    the given XML key and value lists. All attributes are required for parsing except for album
+    artist, play count, and  rating, which default to artist, 0, and None, respectively.
+
+    Args:
+        keys (list(Element)): list of key XML elements
+        values (list(Element)): list of value XML elements
+
+    Returns:
+        a dict containing the desired track attributes
+    """
+    track_dict = {k:v for (k,v) in zip(keys, values)}
+
+    track = Track(*[track_dict[key].strip() for key in REQUIRED_KEYS])
+    track.set_album_artist(track_dict.get(ALBUM_ARTIST_KEY, None))
+    track.set_rating(track_dict.get(RATING_KEY, None))
+    track.set_plays(track_dict.get(PLAY_COUNT_KEY, 0))
+
+    return track
+
+
+def _get_xml_tree(filepath):
+    """Extract an XML tree from a file.
+    
+    Args:
+        filepath (str): iTunes library XML filepath
+
+    Returns:
+        an lxml etree representing the document with tag-external blankspace removed
+    """
+    parser = etree.XMLParser(remove_blank_text=True)
+    return etree.parse(filepath, parser=parser)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("ilib", help="path to iTunes library XML file")
+    args = parser.parse_args()
+    tracks = extract_tracks(args.ilib)

--- a/muslytics/tracks.py
+++ b/muslytics/tracks.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+'''track classes'''
+from __future__ import absolute_import, print_function
+
+
+class ITunesTrack(object):
+    """Representation of an iTunes library music track."""
+
+    def __init__(self, id, name, artist, album, year, genre):
+        """Create a base music track.
+
+        Sets the id, name, artist, album, year, and genre as given.
+        Sets album_artist to artist, rating to None, and plays to 0.
+    
+        Args:
+            id (str): unique track id
+            name (str): track name
+            artist (str): track artist
+            album (str): track album
+            year (str): track year
+            genre (str): track genre
+
+        """
+        self.id = int(id)
+        self.name = name.encode('utf-8')
+        self.artist = artist.encode('utf-8')
+        self.album = album.encode('utf-8')
+        self.year = int(year)
+        self.genre = genre.encode('utf-8')
+
+        self.album_artist = artist.encode('utf-8')
+        self.rating = None
+        self.plays = 0
+
+    def set_album_artist(self, album_artist):
+        """Set the track album artist if given a truthy value.
+
+        Args:
+            album_artist (str): track album artist
+        """
+        if album_artist:
+            self.album_artist = album_artist.encode('utf-8')
+
+    def set_rating(self, rating=None):
+        """Set the track rating if given a truthy value.
+
+        Args:
+            rating (str): track rating, defaults to None
+        """
+        self.rating = int(rating) if rating is not None else None
+
+    def set_plays(self, plays=0):
+        """Set the track play count.
+
+        Args:
+            plays (str): track play count, defualts to 0
+        """
+        self.plays = int(plays)
+
+    def get_identifier(self):
+        """Retrieves a track identifier in the form of concatenated name, artist, year.
+
+        Intended to be used for identifying duplicate tracks.
+
+        Returns:
+            concatenated string of track name, artist, year
+        """
+        return '{name}_{artist}_{year}'.format(name=self.name, artist=self.artist, year=self.year)
+
+    def print_verbose(self):
+        """Creates a verbose string representation.
+        
+        Returns:
+            a verbose string representation of the track attributes
+        """
+        rstr = 'Track ID:\t{id}\n'.format(id=self.id)
+        rstr += 'Name:\t\t{name}\n'.format(name=self.name)
+        rstr += 'Artist:\t\t{artist}\n'.format(artist=self.artist)
+        rstr += 'Album Artist:\t{album_artist}\n'.format(album_artist=self.album_artist)
+        rstr += 'Album:\t\t{album}\n'.format(album=self.album)
+        rstr += 'Year:\t\t{year}\n'.format(year=self.year)
+        rstr += 'Genre:\t\t{genre}\n'.format(genre=self.genre)
+        rstr += 'Rating:\t\t{rating}\n'.format(rating=self.rating)
+        rstr += 'Play Count:\t{plays}\n'.format(plays=self.plays)
+
+        return rstr
+
+    def __repr__(self):
+        rstr = ('({id},{name},{artist},{album_artist},{album},{year},{genre},{rating},{plays})'
+                .format(id=self.id, name=self.name, artist=self.artist,
+                        album_artist=self.album_artist, album=self.album, year=self.year,
+                        genre=self.genre, rating=self.rating, plays=self.plays))
+        return rstr

--- a/tests/sample_lib.xml
+++ b/tests/sample_lib.xml
@@ -48,42 +48,14 @@
         <key>5037</key>
 		<dict>
 			<key>Track ID</key><integer>5037</integer>
-			<key>Size</key><integer>5128035</integer>
-			<key>Total Time</key><integer>248764</integer>
-			<key>Disc Number</key><integer>1</integer>
-			<key>Disc Count</key><integer>1</integer>
-			<key>Track Number</key><integer>1</integer>
-			<key>Track Count</key><integer>1</integer>
 			<key>Year</key><integer>2014</integer>
-			<key>BPM</key><integer>120</integer>
-			<key>Date Modified</key><date>2015-05-17T03:11:07Z</date>
-			<key>Date Added</key><date>2014-08-24T23:44:22Z</date>
-			<key>Bit Rate</key><integer>160</integer>
-			<key>Sample Rate</key><integer>44100</integer>
 			<key>Play Count</key><integer>78</integer>
-			<key>Play Date</key><integer>3561440702</integer>
-			<key>Play Date UTC</key><date>2016-11-08T14:05:02Z</date>
-			<key>Skip Count</key><integer>1</integer>
-			<key>Skip Date</key><date>2015-02-02T22:57:46Z</date>
-			<key>Release Date</key><date>2014-07-29T07:00:00Z</date>
 			<key>Rating</key><integer>80</integer>
-			<key>Album Rating</key><integer>80</integer>
-			<key>Album Rating Computed</key><true/>
-			<key>Persistent ID</key><string>1F820BAAA63C5F20</string>
-			<key>Track Type</key><string>File</string>
-			<key>File Folder Count</key><integer>4</integer>
-			<key>Library Folder Count</key><integer>1</integer>
 			<key>Name</key><string>Pop 101 (feat. Anami Vice)</string>
 			<key>Artist</key><string>Marianas Trench</string>
 			<key>Album Artist</key><string>Marianas Trench</string>
-			<key>Composer</key><string>Josh Ramsay</string>
 			<key>Album</key><string>Pop 101 (feat. Anami Vice) - Single</string>
 			<key>Genre</key><string>Pop</string>
-			<key>Kind</key><string>MPEG audio file</string>
-			<key>Sort Name</key><string>Pop 101 (feat. Anami Vice)</string>
-			<key>Sort Album</key><string>Pop 101 (feat. Anami Vice) - Single</string>
-			<key>Sort Artist</key><string>Marianas Trench</string>
-			<key>Location</key><string>file://localhost/C:/Users/Kaila/Music/iTunes/iTunes%20Media/Marianas%20Trench/Pop%20101%20(feat.%20Anami%20Vice)%20-%20Single/01%20Pop%20101%20(feat.%20Anami%20Vice).mp3</string>
 		</dict>
         <key>5888</key>
 		<dict>

--- a/tests/sample_lib.xml
+++ b/tests/sample_lib.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Application Version</key><string>12.4.1.6</string>
+	<key>Date</key><date>2016-11-14T21:16:09Z</date>
+	<key>Features</key><integer>5</integer>
+	<key>Show Content Ratings</key><true/>
+	<key>Library Persistent ID</key><string>ABCDEF123456</string>
+	<key>Tracks</key>
+	<dict>
+    <key>2383</key>
+		<dict>
+			<key>Track ID</key><integer>2383</integer>
+			<key>Year</key><integer>2008</integer>
+			<key>Play Count</key><integer>1</integer>
+			<key>Has Video</key><true/>
+			<key>Name</key><string>Sandcastles In the Sand - Robin Sparkles (Music Video)</string>
+			<key>Artist</key><string>How I Met Your Mother</string>
+			<key>Album Artist</key><string>How I Met Your Mother</string>
+			<key>Album</key><string>How I Met Your Mother, Season 3</string>
+			<key>Genre</key><string>Comedy</string>
+		</dict>
+        <key>7914</key>
+		<dict>
+			<key>Track ID</key><integer>7914</integer>
+			<key>Year</key><integer>2015</integer>
+			<key>Has Video</key><true/>
+			<key>Name</key><string>Love Boat</string>
+			<key>Artist</key><string>Scorpion</string>
+			<key>Album</key><string>Scorpion, Season 1</string>
+			<key>Genre</key><string>Drama</string>
+		</dict>
+        <key>5035</key>
+		<dict>
+			<key>Track ID</key><integer>5035</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>Play Count</key><integer>261</integer>
+			<key>Rating</key><integer>60</integer>
+			<key>Name</key><string>Shake It Off</string>
+			<key>Artist</key><string>Taylor Swift</string>
+			<key>Album Artist</key><string>Taylor Swift</string>
+			<key>Album</key><string>1989</string>
+			<key>Genre</key><string>Pop</string>
+		</dict>
+        <key>5037</key>
+		<dict>
+			<key>Track ID</key><integer>5037</integer>
+			<key>Size</key><integer>5128035</integer>
+			<key>Total Time</key><integer>248764</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>1</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>BPM</key><integer>120</integer>
+			<key>Date Modified</key><date>2015-05-17T03:11:07Z</date>
+			<key>Date Added</key><date>2014-08-24T23:44:22Z</date>
+			<key>Bit Rate</key><integer>160</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>78</integer>
+			<key>Play Date</key><integer>3561440702</integer>
+			<key>Play Date UTC</key><date>2016-11-08T14:05:02Z</date>
+			<key>Skip Count</key><integer>1</integer>
+			<key>Skip Date</key><date>2015-02-02T22:57:46Z</date>
+			<key>Release Date</key><date>2014-07-29T07:00:00Z</date>
+			<key>Rating</key><integer>80</integer>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Persistent ID</key><string>1F820BAAA63C5F20</string>
+			<key>Track Type</key><string>File</string>
+			<key>File Folder Count</key><integer>4</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+			<key>Name</key><string>Pop 101 (feat. Anami Vice)</string>
+			<key>Artist</key><string>Marianas Trench</string>
+			<key>Album Artist</key><string>Marianas Trench</string>
+			<key>Composer</key><string>Josh Ramsay</string>
+			<key>Album</key><string>Pop 101 (feat. Anami Vice) - Single</string>
+			<key>Genre</key><string>Pop</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Sort Name</key><string>Pop 101 (feat. Anami Vice)</string>
+			<key>Sort Album</key><string>Pop 101 (feat. Anami Vice) - Single</string>
+			<key>Sort Artist</key><string>Marianas Trench</string>
+			<key>Location</key><string>file://localhost/C:/Users/Kaila/Music/iTunes/iTunes%20Media/Marianas%20Trench/Pop%20101%20(feat.%20Anami%20Vice)%20-%20Single/01%20Pop%20101%20(feat.%20Anami%20Vice).mp3</string>
+		</dict>
+        <key>5888</key>
+		<dict>
+			<key>Track ID</key><integer>5888</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>Play Count</key><integer>2906</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Name</key><string>Out of the Woods</string>
+			<key>Artist</key><string>Taylor Swift</string>
+			<key>Album Artist</key><string>Taylor Swift</string>
+			<key>Album</key><string>1989</string>
+			<key>Genre</key><string>Pop</string>
+		</dict>
+        <key>7827</key>
+		<dict>
+			<key>Track ID</key><integer>7827</integer>
+            <key>Year</key><integer>2014</integer>
+            <key>Name</key><string>Slow Rollin'</string>
+			<key>Artist</key><string>Lady Antebellum</string>
+			<key>Album Artist</key><string>Lady Antebellum</string>
+			<key>Album</key><string>747 (Deluxe Edition)</string>
+			<key>Genre</key><string>Country</string>
+		</dict>
+        <key>8755</key>
+		<dict>
+			<key>Track ID</key><integer>8755</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Play Count</key><integer>99</integer>
+            <key>Name</key><string>Frigga</string>
+			<key>Artist</key><string>Daniel J. Nielsen</string>
+			<key>Album</key><string>Epic Action &#38; Inspiration</string>
+			<key>Genre</key><string>Soundtrack</string>
+		</dict>
+        <key>8435</key>
+		<dict>
+			<key>Track ID</key><integer>8435</integer>
+			<key>Year</key><integer>2015</integer>
+			<key>Play Count</key><integer>106</integer>
+            <key>Rating</key><integer>100</integer>
+			<key>Name</key><string>Alexander Hamilton</string>
+			<key>Artist</key><string>Leslie Odom, Jr., Anthony Ramos, Daveed Diggs, Okieriete Onaodowan, Lin-Manuel Miranda, Phillipa Soo, Christopher Jackson &#38; Original Broadway Cast of Hamilton</string>
+			<key>Album</key><string>Hamilton (Original Broadway Cast Recording)</string>
+			<key>Genre</key><string>Soundtrack</string>
+		</dict>
+        <key>5219</key>
+		<dict>
+			<key>Track ID</key><integer>5219</integer>
+			<key>Year</key><integer>2010</integer>
+			<key>Play Count</key><integer>12012</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Name</key><string>Thinking of You</string>
+			<key>Artist</key><string>Christian Kane</string>
+			<key>Album</key><string>Thinking of You - Single</string>
+			<key>Genre</key><string>Country</string>
+		</dict>
+        <key>7830</key>
+		<dict>
+			<key>Track ID</key><integer>7830</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>Rating</key><integer>60</integer>
+			<key>Play Count</key><integer>94</integer>
+			<key>Name</key><string>Out of the Woods</string>
+			<key>Artist</key><string>Taylor Swift</string>
+			<key>Album Artist</key><string>Taylor Swift</string>
+			<key>Album</key><string>1989</string>
+			<key>Genre</key><string>Pop</string>
+		</dict>
+    </dict>
+</dict>
+</plist>

--- a/tests/test_itunes_xml_parser.py
+++ b/tests/test_itunes_xml_parser.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+'''tests itunes library xml parser'''
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from muslytics import ITunesXMLParser as ixml
+
+class TestITunesXMLParser(unittest.TestCase):
+
+    def setUp(self):
+        self.tracks = ixml.extract_tracks('sample_lib.xml')
+        pass
+
+    def test_extracted_tracks(self):
+        self.assertEqual(len(self.tracks), 8)
+
+        ootws = filter(lambda track: track.name == 'Out of the Woods', self.tracks)
+        self.assertEqual(len(ootws), 2)
+
+        ootw = ootws[0]
+        self.assertEqual(ootw.artist, 'Taylor Swift')
+        self.assertEqual(ootw.album, '1989')
+        self.assertEqual(ootw.album_artist, 'Taylor Swift')
+        self.assertEqual(ootw.year, 2014)
+        self.assertEqual(ootw.genre, 'Pop')
+
+        play_counts = map(lambda track: track.plays, ootws)
+        self.assertIn(2906, play_counts)
+        self.assertIn(94, play_counts)
+
+        ratings = map(lambda track: track.rating, ootws)
+        self.assertIn(60, ratings)
+        self.assertIn(100, ratings)
+
+        ids = map(lambda track: track.id, ootws)
+        self.assertIn(5888, ids)
+        self.assertIn(7830, ids)
+
+
+    def test_merged_tracks(self):
+        ixml.merge_duplicates(self.tracks)
+
+        self.assertEqual(len(self.tracks), 7)
+
+        ootws = filter(lambda track: track.name == 'Out of the Woods', self.tracks)
+        self.assertEqual(len(ootws), 1)
+
+        ootw = ootws[0]
+        self.assertEqual(ootw.artist, 'Taylor Swift')
+        self.assertEqual(ootw.album, '1989')
+        self.assertEqual(ootw.album_artist, 'Taylor Swift')
+        self.assertEqual(ootw.year, 2014)
+        self.assertEqual(ootw.genre, 'Pop')
+        self.assertEqual(ootw.plays, 3000)
+        self.assertEqual(ootw.rating, 80)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Contains parsing capability for iTunes library XML file, and allows libraries to be pickled and unpickled.

Added sample library file and unit tests.
