### PR TITLE
Move genre to tracks and add album artists

### DIFF
--- a/muslytics/utils.py
+++ b/muslytics/utils.py
@@ -3,35 +3,40 @@
 from __future__ import absolute_import, print_function
 
 import logging
+import re
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('Library Objects')
+
+SUB_FEAT_PAT = re.compile('\s*\(feat\.(?P<artist>.*)\)\s*')
+FEAT_PATTERN = re.compile('.*\(feat\.(?P<artist>.*)\)\s*')
+MULT_PATTERN = re.compile('\s*[,&]\s*')
 
 
 class Album(object):
     """A collection of tracks in an album."""
 
-    def __init__(self, name, year, genre):
+    def __init__(self, name, year):
         """Create a music album with no tracks.
 
         Args:
             name (str): album name
             year (int): album year
-            genre (str): album genre
         """
         self.name = name
         self.year = year
-        self.genre = genre
 
         self.tracks = []
+        self.artists = set()
 
     def add_track(self, track):
-        """Add a track to the music album.
+        """Add a track to the music album, updating album artists as necessary.
 
         Args:
             track (ITunesTrack): iTunes track from library XML
         """
         self.tracks.append(track)
+        self.artists.update(track.artists)
 
     def merge_duplicates(self):
         """Merge duplicate tracks into one and remove extraneous.
@@ -87,31 +92,39 @@ class Album(object):
                                  remained=len(self.tracks)))
 
     def __repr__(self):
-        return ('({name},{year},{genre},{track_count})'
-                .format(name=self.name, year=self.year,
-                        genre=self.genre, track_count=len(self.tracks)))
+        return ('({name},{artists},{year},{track_count})'
+                .format(name=self.name, artists=self.artists, year=self.year,
+                        track_count=len(self.tracks)))
 
+class Track(object):
+    """Abstract representation of a track."""
 
-class ITunesTrack(object):
-    """Representation of an iTunes library music track."""
+    def __init__(self, id, name, artists, genre='', rating=None, plays=0):
+        """Base track representation.
 
-    def __init__(self, id, name, artist):
-        """Create a base music track.
-
-        Sets the id, name, and artist as given.
-        Defaults rating to None and plays to 0.
-    
         Args:
-            id (str): unique track id
+            id (int): track id
             name (str): track name
-            artist (str): track artist
-
+            artists (list[str]): track artists
+            genre (str): track genre, defaults to ''
+            rating (float): track rating, defaults to None
+            plays (int): track play count, defaults to 0
         """
-        self.id = int(id)
+        self.id = id
         self.name = name
-        self.artist = artist
-        self.rating = None
-        self.plays = 0
+        self.artists = artists
+        self.genre = genre
+        self.rating = rating
+        self.plays = plays
+
+
+    def set_genre(self, genre=''):
+        """Set the track genre if given a truthy value.
+
+        Args:
+            genre (str): track genre, defaults to ''
+        """
+        self.genre = genre
 
     def set_rating(self, rating=None):
         """Set the track rating if given a truthy value.
@@ -130,14 +143,41 @@ class ITunesTrack(object):
         self.plays = int(plays)
 
     def get_track_identifier(self):
-        """Retrieves a track identifier in the form of its name and artist.
+        """Retrieves a track identifier in the form of its name and artists.
 
         Intended to be used for identifying duplicate tracks within the same album.
 
         Returns:
-            tuple of track name, artist
+            tuple of track name, artists
         """
-        return (self.name, self.artist)
+        return (self.name, ','.join(self.artists))
+
+
+class ITunesTrack(Track):
+    """Representation of an iTunes library music track."""
+
+    def __init__(self, id, name, artists):
+        """Create a base music track.
+
+        Sets the id, name, and artist as given.
+        If there are multiple or featured artists they will be combined in a set.
+        Defaults rating to None and plays to 0.
+
+        Args:
+            id (str): unique track id
+            name (str): track name
+            artists (str): track artists
+
+        """
+        feat_artists = FEAT_PATTERN.match(name)
+        name = SUB_FEAT_PAT.sub('', name)
+        artists = set(re.split(MULT_PATTERN, artists))
+
+        if feat_artists:
+            feat_artists = re.split(MULT_PATTERN, feat_artists.group('artist').strip())
+            artists.update(feat_artists)
+
+        super(ITunesTrack, self).__init__(int(id), name, artists, None, 0)
 
     def print_verbose(self):
         """Creates a verbose string representation.
@@ -147,14 +187,15 @@ class ITunesTrack(object):
         """
         rstr = 'Track ID:\t{id}\n'.format(id=self.id)
         rstr += 'Name:\t\t{name}\n'.format(name=self.name)
-        rstr += 'Artist:\t\t{artist}\n'.format(artist=self.artist)
+        rstr += 'Artists:\t\t{artist}\n'.format(artist=','.join(self.artists))
+        rstr += 'Genre:\t\t{genre}\n'.format(genre=self.genre)
         rstr += 'Rating:\t\t{rating}\n'.format(rating=self.rating)
         rstr += 'Play Count:\t{plays}\n'.format(plays=self.plays)
 
         return rstr
 
     def __repr__(self):
-        rstr = ('({id},{name},{artist},{rating},{plays})'
-                .format(id=self.id, name=self.name, artist=self.artist,
-                        rating=self.rating, plays=self.plays))
+        rstr = ('({id},{name},({artists}),{genre},{rating},{plays})'
+                .format(id=self.id, name=self.name, artists=','.join(self.artists),
+                        genre=self.genre, rating=self.rating, plays=self.plays))
         return rstr

--- a/tests/sample_lib.xml
+++ b/tests/sample_lib.xml
@@ -111,6 +111,39 @@
 			<key>Album</key><string>Thinking of You - Single</string>
 			<key>Genre</key><string>Country</string>
 		</dict>
+        <key>8753</key>
+		<dict>
+			<key>Track ID</key><integer>8753</integer>
+			<key>Year</key><integer>2016</integer>
+			<key>Name</key><string>My Shot (feat. Busta Rhymes, Joell Ortiz &#38; Nate Ruess) [Rise Up Remix]</string>
+			<key>Artist</key><string>The Roots</string>
+			<key>Album Artist</key><string>Various Artists</string>
+			<key>Album</key><string>The Hamilton Mixtape</string>
+			<key>Genre</key><string>Hip-Hop/Rap</string>
+		</dict>
+        <key>8755</key>
+		<dict>
+			<key>Track ID</key><integer>8755</integer>
+			<key>Year</key><integer>2016</integer>
+			<key>Play Count</key><integer>7</integer>
+			<key>Name</key><string>Satisfied (feat. Miguel &#38; Queen Latifah)</string>
+			<key>Artist</key><string>Sia</string>
+			<key>Album Artist</key><string>Various Artists</string>
+			<key>Album</key><string>The Hamilton Mixtape</string>
+			<key>Genre</key><string>Pop</string>
+		</dict>
+        <key>6031</key>
+		<dict>
+			<key>Track ID</key><integer>6031</integer>
+			<key>Year</key><integer>2015</integer>
+			<key>Play Count</key><integer>336</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Name</key><string>Love Me Like You Do</string>
+			<key>Artist</key><string>Madilyn Bailey &#38; MAX</string>
+			<key>Album Artist</key><string>Madilyn Bailey &#38; MAX</string>
+			<key>Album</key><string>Love Me Like You Do - Single</string>
+			<key>Genre</key><string>Singer/Songwriter</string>
+		</dict>
         <key>7830</key>
 		<dict>
 			<key>Track ID</key><integer>7830</integer>

--- a/tests/test_itunes_xml_parser.py
+++ b/tests/test_itunes_xml_parser.py
@@ -10,52 +10,53 @@ from muslytics import ITunesXMLParser as ixml
 class TestITunesXMLParser(unittest.TestCase):
 
     def setUp(self):
-        sample_path = os.path.dirname(os.path.realpath(__file__))
-        self.sample_path = os.path.join(sample_path, 'sample_lib.xml')
-        pass
+        sample_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   'sample_lib.xml')
+        self.albums = ixml.extract_albums(sample_path)
 
-    def test_extracted_and_merged_albums(self):
-        albums = ixml.extract_albums(self.sample_path)
+    def test_extracted_albums(self):
+        self.assertEqual(len(self.albums), 8)
 
-        self.assertEqual(len(albums), 6)
-        self.assertEqual(sum(len(album.tracks) for album in albums.values()), 8)
+    def test_merged_tracks(self):
+        self.assertEqual(sum(len(album.tracks) for album in self.albums.values()), 10)
 
-        album_key = ('1989', 2014, 'Pop')
-        self.assertIn(album_key, albums)
-        album = albums[album_key]
-        self.assertEqual(len(album.tracks), 3)
-
-        ootws = filter(lambda track: track.name == 'Out of the Woods', album.tracks)
-        self.assertEqual(len(ootws), 2)
-
-        ootw = ootws[0]
-        self.assertEqual(ootw.artist, 'Taylor Swift')
-
-        play_counts = map(lambda track: track.plays, ootws)
-        self.assertIn(2906, play_counts)
-        self.assertIn(94, play_counts)
-
-        ratings = map(lambda track: track.rating, ootws)
-        self.assertIn(60, ratings)
-        self.assertIn(100, ratings)
-
-        ids = map(lambda track: track.id, ootws)
-        self.assertIn(5888, ids)
-        self.assertIn(7830, ids)
-
-        for a in albums.values():
-            a.merge_duplicates()
-
-        self.assertEqual(sum(len(a.tracks) for a in albums.values()), 7)
+        album_key = ('1989', 2014)
+        self.assertIn(album_key, self.albums)
+        album = self.albums[album_key]
         self.assertEqual(len(album.tracks), 2)
 
         ootws = filter(lambda track: track.name == 'Out of the Woods', album.tracks)
         self.assertEqual(len(ootws), 1)
 
         ootw = ootws[0]
-        self.assertEqual(ootw.artist, 'Taylor Swift')
+        self.assertIn('Taylor Swift', ootw.artists)
+        self.assertIn('Taylor Swift', album.artists)
+        self.assertEqual(ootw.genre, 'Pop')
         self.assertEqual(ootw.plays, 3000)
         self.assertEqual(ootw.rating, 80)
+
+    def test_artists(self):
+        album_key = ('The Hamilton Mixtape', 2016)
+        self.assertIn(album_key, self.albums)
+        album = self.albums[album_key]
+        self.assertEqual(len(album.tracks), 2)
+        self.assertEqual(len(album.artists), 7)
+
+        album_artists = set()
+        for track in album.tracks:
+            album_artists.update(track.artists)
+
+        self.assertEqual(len(album_artists - album.artists), 0)
+        self.assertEqual(len(album.artists - album_artists), 0)
+
+        album_key = ('Love Me Like You Do - Single', 2015)
+        self.assertIn(album_key, self.albums)
+        album = self.albums[album_key]
+        self.assertEqual(len(album.artists), 2)
+        self.assertEqual(len(album.tracks), 1)
+        self.assertEqual(len(album.tracks[0].artists), 2)
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Discovered that a genre is not an identifier of an album, so pushed that
back to the track level. Split the artist strings to support multiple
artists, and bumped up to the album level, too, to help with Spotify
queries.