### PR TITLE
Reorganization of ITunesUtils, changes some fields

### DIFF
--- a/muslytics/Utils.py
+++ b/muslytics/Utils.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 UNKNOWN_GENRE = 0
 
 ALBUM_NAME_PATTERN = re.compile('\s*((\-\s*(Single|EP))|(\(.*Deluxe.*\))|(\[.*Deluxe.*\]))\s*')
+MULT_ARTIST_PATTERN = re.compile('\s*[,&]\s*')
+FEAT_ARTIST_PATTERN = re.compile('\s*(\(feat\..*\)|\-\s*feat\..*)\s*')
 
 def get_album_name(name):
     """Strip extraneous info from album name.
@@ -26,80 +28,32 @@ def get_album_name(name):
     Returns:
         the album name with extraneous info removed
     """
-    name = name.strip().encode('utf-8')
+    name = name.strip()
     return re.sub(ALBUM_NAME_PATTERN, '', name)
+
+
+def strip_featured_artists(name):
+    """Strip '(feat. X)' artist info from a song title.
+
+    Args:
+        name (str): song title
+
+    Returns:
+        the song title without any featured artists
+    """
+    return FEAT_ARTIST_PATTERN.sub(' ', name).strip()
+
 
 class Track(object):
     """Abstract representation of a track."""
 
-    def __init__(self, id, name, artists, genre=UNKNOWN_GENRE,
-            track_number=None, rating=None, plays=0):
+    def __init__(self, id, name):
         """Base track representation.
 
         Args:
             id (int): track id
             name (str): track name
-            artists (list[str]): track artists
-            genre (str): track genre, defaults to UNKNOWN_GENRE
-            track_number (int): track number, defaults to None
-            rating (float): track rating, defaults to None
-            plays (int): track play count, defaults to 0
         """
         self.id = id
         self.name = name
-        self.artists = artists
-        self.genre = genre
-        self.track_number = track_number
-        self.rating = rating
-        self.plays = plays
-        self.album_id = None
 
-    def set_genre(self, genre=UNKNOWN_GENRE):
-        """Set the track genre.
-
-        Args:
-            genre (int): track genre, defaults to UNKNOWN_GENRE
-        """
-        self.genre = genre
-
-    def set_rating(self, rating=None):
-        """Set the track rating if given a truthy value.
-
-        Args:
-            rating (str): track rating, defaults to None
-        """
-        self.rating = int(rating) if rating is not None else None
-
-    def set_plays(self, plays=0):
-        """Set the track play count.
-
-        Args:
-            plays (str): track play count, defaults to 0
-        """
-        self.plays = int(plays)
-
-    def set_track_number(self, track_number=None):
-        """Set the track number.
-
-        Args:
-            track_number (int): track number, defaults to None
-        """
-        self.track_number = int(track_number) if track_number is not None else None
-
-    def set_album_id(self, album_id):
-        """Set the album id.
-
-        Args:
-            album_id (tuple): unique album identifier
-        """
-        self.album_id = album_id
-
-    def get_track_identifier(self):
-        """Retrieves a track identifier in the form of its name and artists.
-
-        Intended to be used for identifying duplicate tracks within the same album.
-
-        Returns:
-            tuple of track name, artists
-        """
-        return (self.name, ','.join(self.artists))

--- a/tests/sample_lib.xml
+++ b/tests/sample_lib.xml
@@ -36,7 +36,6 @@
         <key>5035</key>
 		<dict>
 			<key>Track ID</key><integer>5035</integer>
-			<key>Track Number</key><integer>6</integer>
 			<key>Year</key><integer>2014</integer>
 			<key>Play Count</key><integer>261</integer>
 			<key>Rating</key><integer>60</integer>
@@ -49,7 +48,6 @@
         <key>5037</key>
 		<dict>
 			<key>Track ID</key><integer>5037</integer>
-			<key>Track Number</key><integer>1</integer>
 			<key>Year</key><integer>2014</integer>
 			<key>Play Count</key><integer>78</integer>
 			<key>Rating</key><integer>80</integer>
@@ -62,10 +60,10 @@
         <key>5888</key>
 		<dict>
 			<key>Track ID</key><integer>5888</integer>
-			<key>Track Number</key><integer>4</integer>
 			<key>Year</key><integer>2014</integer>
 			<key>Play Count</key><integer>2906</integer>
 			<key>Rating</key><integer>100</integer>
+			<key>Loved</key><true/>
 			<key>Name</key><string>Out of the Woods</string>
 			<key>Artist</key><string>Taylor Swift</string>
 			<key>Album Artist</key><string>Taylor Swift</string>
@@ -75,8 +73,8 @@
         <key>7827</key>
 		<dict>
 			<key>Track ID</key><integer>7827</integer>
-			<key>Track Number</key><integer>12</integer>
             <key>Year</key><integer>2014</integer>
+			<key>Rating</key><integer>80</integer>
             <key>Name</key><string>Slow Rollin'</string>
 			<key>Artist</key><string>Lady Antebellum</string>
 			<key>Album Artist</key><string>Lady Antebellum</string>
@@ -86,9 +84,10 @@
         <key>8755</key>
 		<dict>
 			<key>Track ID</key><integer>8755</integer>
-			<key>Track Number</key><integer>9</integer>
 			<key>Year</key><integer>2012</integer>
 			<key>Play Count</key><integer>99</integer>
+			<key>Loved</key><true/>
+			<key>Rating</key><integer>100</integer>
             <key>Name</key><string>Frigga</string>
 			<key>Artist</key><string>Daniel J. Nielsen</string>
 			<key>Album</key><string>Epic Action &#38; Inspiration</string>
@@ -97,7 +96,6 @@
         <key>8435</key>
 		<dict>
 			<key>Track ID</key><integer>8435</integer>
-			<key>Track Number</key><integer>1</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>106</integer>
             <key>Rating</key><integer>100</integer>
@@ -109,10 +107,10 @@
         <key>5219</key>
 		<dict>
 			<key>Track ID</key><integer>5219</integer>
-			<key>Track Number</key><integer>1</integer>
 			<key>Year</key><integer>2010</integer>
 			<key>Play Count</key><integer>12012</integer>
 			<key>Rating</key><integer>100</integer>
+			<key>Loved</key><true/>
 			<key>Name</key><string>Thinking of You</string>
 			<key>Artist</key><string>Christian Kane</string>
 			<key>Album</key><string>Thinking of You - Single</string>
@@ -121,8 +119,8 @@
         <key>8753</key>
 		<dict>
 			<key>Track ID</key><integer>8753</integer>
-			<key>Track Number</key><integer>2</integer>
 			<key>Year</key><integer>2016</integer>
+			<key>Rating</key><integer>60</integer>
 			<key>Name</key><string>My Shot (feat. Busta Rhymes, Joell Ortiz &#38; Nate Ruess) [Rise Up Remix]</string>
 			<key>Artist</key><string>The Roots</string>
 			<key>Album Artist</key><string>Various Artists</string>
@@ -132,9 +130,9 @@
         <key>8755</key>
 		<dict>
 			<key>Track ID</key><integer>8755</integer>
-			<key>Track Number</key><integer>6</integer>
 			<key>Year</key><integer>2016</integer>
 			<key>Play Count</key><integer>7</integer>
+			<key>Rating</key><integer>80</integer>
 			<key>Name</key><string>Satisfied (feat. Miguel &#38; Queen Latifah)</string>
 			<key>Artist</key><string>Sia</string>
 			<key>Album Artist</key><string>Various Artists</string>
@@ -144,7 +142,6 @@
         <key>6031</key>
 		<dict>
 			<key>Track ID</key><integer>6031</integer>
-			<key>Track Number</key><integer>1</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>336</integer>
 			<key>Rating</key><integer>100</integer>
@@ -157,7 +154,6 @@
         <key>7830</key>
 		<dict>
 			<key>Track ID</key><integer>7830</integer>
-			<key>Track Number</key><integer>4</integer>
 			<key>Year</key><integer>2014</integer>
 			<key>Rating</key><integer>60</integer>
 			<key>Play Count</key><integer>94</integer>
@@ -170,9 +166,9 @@
         <key>8737</key>
 		<dict>
 			<key>Track ID</key><integer>8737</integer>
-			<key>Track Number</key><integer>13</integer>
 			<key>Year</key><integer>2016</integer>
 			<key>Play Count</key><integer>372</integer>
+			<key>Rating</key><integer>80</integer>
 			<key>Name</key><string>How Far I'll Go (Alessia Cara Version)</string>
 			<key>Artist</key><string>Alessia Cara</string>
 			<key>Album</key><string>Moana (Original Motion Picture Soundtrack) [Deluxe Edition]</string>
@@ -181,11 +177,9 @@
         <key>5789</key>
 		<dict>
 			<key>Track ID</key><integer>5789</integer>
-			<key>Track Number</key><integer>1</integer>
 			<key>Year</key><integer>2014</integer>
 			<key>Play Count</key><integer>191</integer>
 			<key>Rating</key><integer>80</integer>
-			<key>Album Rating</key><integer>80</integer>
 			<key>Name</key><string>Just Watch Me</string>
 			<key>Artist</key><string>Kate Voegele</string>
 			<key>Album Artist</key><string>Kate Voegele</string>
@@ -195,7 +189,6 @@
         <key>6427</key>
 		<dict>
 			<key>Track ID</key><integer>6427</integer>
-			<key>Track Number</key><integer>8</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>42</integer>
 			<key>Rating</key><integer>100</integer>
@@ -207,7 +200,6 @@
         <key>6425</key>
 		<dict>
 			<key>Track ID</key><integer>6425</integer>
-			<key>Track Number</key><integer>14</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>37</integer>
 			<key>Rating</key><integer>100</integer>
@@ -219,10 +211,10 @@
         <key>6209</key>
 		<dict>
 			<key>Track ID</key><integer>6209</integer>
-			<key>Track Number</key><integer>2</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>34</integer>
 			<key>Rating</key><integer>80</integer>
+			<key>Loved</key><true/>
 			<key>Name</key><string>Break Up with Him</string>
 			<key>Artist</key><string>Old Dominion</string>
 			<key>Album</key><string>Old Dominion - EP</string>
@@ -231,7 +223,6 @@
         <key>6211</key>
 		<dict>
 			<key>Track ID</key><integer>6211</integer>
-			<key>Track Number</key><integer>8</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>66</integer>
 			<key>Rating</key><integer>40</integer>
@@ -243,13 +234,37 @@
         <key>8583</key>
 		<dict>
 			<key>Track ID</key><integer>8583</integer>
-			<key>Track Number</key><integer>9</integer>
 			<key>Year</key><integer>2015</integer>
 			<key>Play Count</key><integer>1</integer>
+			<key>Rating</key><integer>60</integer>
 			<key>Name</key><string>Song for Another Time</string>
 			<key>Artist</key><string>Old Dominion</string>
 			<key>Album</key><string>Meat and Candy</string>
 			<key>Genre</key><string>Country</string>
+		</dict>
+        <key>6707</key>
+		<dict>
+			<key>Track ID</key><integer>6707</integer>
+			<key>Year</key><integer>2015</integer>
+			<key>Play Count</key><integer>1124</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Name</key><string>Ecos de amor</string>
+			<key>Artist</key><string>Jesse &#38; Joy</string>
+			<key>Album Artist</key><string>Jesse &#38; Joy</string>
+			<key>Album</key><string>Un besito más</string>
+			<key>Genre</key><string>Pop Latino</string>
+		</dict>
+        <key>6699</key>
+		<dict>
+			<key>Track ID</key><integer>6699</integer>
+			<key>Year</key><integer>2015</integer>
+			<key>Play Count</key><integer>27</integer>
+			<key>Rating</key><integer>40</integer>
+			<key>Name</key><string>Un besito más (feat. Juan Luis Guerra)</string>
+			<key>Artist</key><string>Jesse &#38; Joy</string>
+			<key>Album Artist</key><string>Jesse &#38; Joy</string>
+			<key>Album</key><string>Un besito más</string>
+			<key>Genre</key><string>Pop Latino</string>
 		</dict>
     </dict>
 </dict>

--- a/tests/test_itunes_xml_parser.py
+++ b/tests/test_itunes_xml_parser.py
@@ -21,13 +21,13 @@ class TestITunesXMLParser(unittest.TestCase):
     def test_extracted_library(self):
         """Verify that extraction works."""
         library = ixml.extract_library(self.sample_path, remove_duplicates=False)
-        self.assertEqual(len(library.albums), 13)
-        self.assertEqual(len(library.tracks), 17)
-        self.assertEqual(len(library.artists), 13)
+        self.assertEqual(len(library.albums), 14)
+        self.assertEqual(len(library.tracks), 19)
+        self.assertEqual(len(library.artists), 14)
         self.assertEqual(len(library.genres), 7)
 
     def _test_merged_track(self, album_key, tracks_in_album, track_name, artist,
-            genre, plays, rating):
+            genre, plays, rating, loved):
         """Helper to verify an individual track."""
         self.assertIn(album_key, self.library.albums)
         album = self.library.albums[album_key]
@@ -41,19 +41,20 @@ class TestITunesXMLParser(unittest.TestCase):
         track = tracks[0]
         self.assertIn(artist, track.artists)
         self.assertIn(artist, album.artists)
-        self.assertEqual(self.library.genres[track.genre], genre)
+        self.assertEqual(track.genre, genre)
         self.assertEqual(track.plays, plays)
         self.assertEqual(track.rating, rating)
+        self.assertEqual(track.loved, loved)
 
     def test_merged_tracks(self):
         """Verify that duplicates are merged/removed properly."""
-        self.assertEqual(len(self.library.albums), 12)
-        self.assertEqual(len(self.library.tracks), 15)
+        self.assertEqual(len(self.library.albums), 13)
+        self.assertEqual(len(self.library.tracks), 17)
 
         self._test_merged_track(('1989', 2014), 2, 'Out of the Woods', 'Taylor Swift',
-                'Pop', 3000, 80)
+                'pop', 3000, 80, True)
         self._test_merged_track(('Meat and Candy', 2015), 2, 'Break Up with Him', 'Old Dominion',
-                'Country', 100, 60)
+                'country', 100, 60, True)
 
     def test_artists(self):
         """Verify that multiple artists are split correctly."""


### PR DESCRIPTION
Cleaner split between abstract Track class and ITunesTrack class so that
when SpotifyTracks exist they can also subclass from Track. Removes
track number, updates track genre, and adds loved fields. Also doesn't
add podcasts. Better support for unicode characters.

Updated and passes test cases.